### PR TITLE
Fixed UDP disabling through app preferences

### DIFF
--- a/app/src/main/scala/chat/tox/antox/tox/ToxSingleton.scala
+++ b/app/src/main/scala/chat/tox/antox/tox/ToxSingleton.scala
@@ -152,8 +152,8 @@ object ToxSingleton {
 
     val udpEnabled = preferences.getBoolean("enable_udp", false)
     val options = new ToxOptions(
-      udpEnabled,
       Options.ipv6Enabled,
+      udpEnabled,
       saveData = dataFile.loadAsSaveType())
 
     try {


### PR DESCRIPTION
UDP and IPv6 options are misplaced in ToxOptions instance creation